### PR TITLE
Fix ponder crashes when calling FluidTankBlockEntity#getControllerBE

### DIFF
--- a/src/main/java/com/hlysine/create_power_loader/CPLPonders.java
+++ b/src/main/java/com/hlysine/create_power_loader/CPLPonders.java
@@ -3,7 +3,6 @@ package com.hlysine.create_power_loader;
 import com.hlysine.create_power_loader.ponder.AndesiteChunkLoaderScenes;
 import com.hlysine.create_power_loader.ponder.BrassChunkLoaderScenes;
 import com.hlysine.create_power_loader.ponder.EmptyChunkLoaderScenes;
-import com.simibubi.create.foundation.ponder.PonderWorldBlockEntityFix;
 import com.simibubi.create.infrastructure.ponder.AllCreatePonderTags;
 import com.tterrag.registrate.util.entry.ItemProviderEntry;
 import net.createmod.ponder.api.level.PonderLevel;
@@ -33,9 +32,7 @@ public class CPLPonders implements PonderPlugin {
     }
 
     @Override
-    public void onPonderLevelRestore(PonderLevel ponderLevel) {
-        PonderWorldBlockEntityFix.fixControllerBlockEntities(ponderLevel);
-    }
+    public void onPonderLevelRestore(PonderLevel ponderLevel) {}
 
     @Override
     public void indexExclusions(IndexExclusionHelper helper) {


### PR DESCRIPTION
`CPLPonders#onPonderLevelRestore` calls `PonderWorldBlockEntityFix#fixControllerBlockEntities`, which causes controller BE position being adjusted twice. Because `PonderWorldBlockEntityFix#fixControllerBlockEntities` is applied globally (to all ponder scene) instead of seperately.

I Found this issue from multiple crash reports of C:EI. For example: https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/286