### PR TITLE
Fix translations for chunk loading radius not being used

### DIFF
--- a/src/main/resources/assets/create_power_loader/lang/en_us.json
+++ b/src/main/resources/assets/create_power_loader/lang/en_us.json
@@ -7,9 +7,9 @@
   "block.create_power_loader.empty_brass_chunk_loader": "Empty Brass Chunk Loader",
   "block.create_power_loader.brass_chunk_loader": "Brass Chunk Loader",
   "create_power_loader.brass_chunk_loader.loading_range": "Chunk Loading Radius",
-  "create.create_power_loader.brass_chunk_loader.load_1x1": "1x1 Square",
-  "create.create_power_loader.brass_chunk_loader.load_3x3": "3x3 Square",
-  "create.create_power_loader.brass_chunk_loader.load_5x5": "5x5 Square",
+  "create_power_loader.brass_chunk_loader.load_1x1": "1x1 Square",
+  "create_power_loader.brass_chunk_loader.load_3x3": "3x3 Square",
+  "create_power_loader.brass_chunk_loader.load_5x5": "5x5 Square",
 
   "create_power_loader.ponder.empty_chunk_loader_basic.header": "Usage of Empty Chunk Loaders",
   "create_power_loader.ponder.empty_chunk_loader_basic.text_1": "Right-click a Ghast with an empty chunk loader to capture it",

--- a/src/main/resources/assets/create_power_loader/lang/fr_fr.json
+++ b/src/main/resources/assets/create_power_loader/lang/fr_fr.json
@@ -7,9 +7,9 @@
   "block.create_power_loader.empty_brass_chunk_loader": "Chargeur de chunk en laiton vide",
   "block.create_power_loader.brass_chunk_loader": "Chargeur de chunk en laiton",
   "create_power_loader.brass_chunk_loader.loading_range": "Rayon de chargement de chunk",
-  "create.create_power_loader.brass_chunk_loader.load_1x1": "Carré de 1x1",
-  "create.create_power_loader.brass_chunk_loader.load_3x3": "Carré de 3x3",
-  "create.create_power_loader.brass_chunk_loader.load_5x5": "Carré de 5x5 ",
+  "create_power_loader.brass_chunk_loader.load_1x1": "Carré de 1x1",
+  "create_power_loader.brass_chunk_loader.load_3x3": "Carré de 3x3",
+  "create_power_loader.brass_chunk_loader.load_5x5": "Carré de 5x5 ",
 
   "create_power_loader.ponder.empty_chunk_loader_basic.header": "Utilisation des chargeurs de chunk vides",
   "create_power_loader.ponder.empty_chunk_loader_basic.text_1": "Clic droit sur un ghast avec un chargeur de chunk vide pour le capturer",

--- a/src/main/resources/assets/create_power_loader/lang/ja_jp.json
+++ b/src/main/resources/assets/create_power_loader/lang/ja_jp.json
@@ -7,9 +7,9 @@
   "block.create_power_loader.empty_brass_chunk_loader": "空の真鍮チャンクローダー",
   "block.create_power_loader.brass_chunk_loader": "真鍮チャンクローダー",
   "create_power_loader.brass_chunk_loader.loading_range": "チャンクの読み込み半径",
-  "create.create_power_loader.brass_chunk_loader.load_1x1": "1x1の四角形",
-  "create.create_power_loader.brass_chunk_loader.load_3x3": "3x3の四角形",
-  "create.create_power_loader.brass_chunk_loader.load_5x5": "5x5の四角形",
+  "create_power_loader.brass_chunk_loader.load_1x1": "1x1の四角形",
+  "create_power_loader.brass_chunk_loader.load_3x3": "3x3の四角形",
+  "create_power_loader.brass_chunk_loader.load_5x5": "5x5の四角形",
 
   "create_power_loader.ponder.empty_chunk_loader_basic.header": "空のチャンクローダーの使い方",
   "create_power_loader.ponder.empty_chunk_loader_basic.text_1": "空のチャンクローダーで右クリックするとガストを捕獲できます",

--- a/src/main/resources/assets/create_power_loader/lang/ko_kr.json
+++ b/src/main/resources/assets/create_power_loader/lang/ko_kr.json
@@ -7,9 +7,9 @@
   "block.create_power_loader.empty_brass_chunk_loader": "빈 황동 청크 로더",
   "block.create_power_loader.brass_chunk_loader": "황동 청크 로더",
   "create_power_loader.brass_chunk_loader.loading_range": "청크 로딩 반경",
-  "create.create_power_loader.brass_chunk_loader.load_1x1": "1x1",
-  "create.create_power_loader.brass_chunk_loader.load_3x3": "3x3",
-  "create.create_power_loader.brass_chunk_loader.load_5x5": "5x5",
+  "create_power_loader.brass_chunk_loader.load_1x1": "1x1",
+  "create_power_loader.brass_chunk_loader.load_3x3": "3x3",
+  "create_power_loader.brass_chunk_loader.load_5x5": "5x5",
 
   "create_power_loader.ponder.empty_chunk_loader_basic.header": "빈 청크 로더의 사용법",
   "create_power_loader.ponder.empty_chunk_loader_basic.text_1": "가스트를 우클릭하여 청크 로더에 가둡니다",

--- a/src/main/resources/assets/create_power_loader/lang/ru_ru.json
+++ b/src/main/resources/assets/create_power_loader/lang/ru_ru.json
@@ -7,9 +7,9 @@
   "block.create_power_loader.empty_brass_chunk_loader": "Пустой латунный загрузчик чанков",
   "block.create_power_loader.brass_chunk_loader": "Латунный загрузчик чанков",
   "create_power_loader.brass_chunk_loader.loading_range": "Радиус загрузки чанков",
-  "create.create_power_loader.brass_chunk_loader.load_1x1": "Квадрат 1x1",
-  "create.create_power_loader.brass_chunk_loader.load_3x3": "Квадрат 3x3",
-  "create.create_power_loader.brass_chunk_loader.load_5x5": "Квадрат 5x5",
+  "create_power_loader.brass_chunk_loader.load_1x1": "Квадрат 1x1",
+  "create_power_loader.brass_chunk_loader.load_3x3": "Квадрат 3x3",
+  "create_power_loader.brass_chunk_loader.load_5x5": "Квадрат 5x5",
 
   "create_power_loader.ponder.empty_chunk_loader_basic.header": "Поимкой гастов в пустые загрузчики",
   "create_power_loader.ponder.empty_chunk_loader_basic.text_1": "Кликните ПКМ по гасту с пустым загрузчиком, чтобы захватить его",

--- a/src/main/resources/assets/create_power_loader/lang/tr_tr.json
+++ b/src/main/resources/assets/create_power_loader/lang/tr_tr.json
@@ -7,9 +7,9 @@
   "block.create_power_loader.empty_brass_chunk_loader": "Boş Pirinç Yığın Yükleyici",
   "block.create_power_loader.brass_chunk_loader": "Pirinç Yığın Yükleyici",
   "create_power_loader.brass_chunk_loader.loading_range": "Yığın Yükleme Çapı",
-  "create.create_power_loader.brass_chunk_loader.load_1x1": "1x1 Kare",
-  "create.create_power_loader.brass_chunk_loader.load_3x3": "3x3 Kare",
-  "create.create_power_loader.brass_chunk_loader.load_5x5": "5x5 Kare",
+  "create_power_loader.brass_chunk_loader.load_1x1": "1x1 Kare",
+  "create_power_loader.brass_chunk_loader.load_3x3": "3x3 Kare",
+  "create_power_loader.brass_chunk_loader.load_5x5": "5x5 Kare",
   
   "create_power_loader.ponder.empty_chunk_loader_basic.header": "Boş Yığın Yükleyicilerin Kullanımı",
   "create_power_loader.ponder.empty_chunk_loader_basic.text_1": "Bir boş yığın yükleyici ile bir Ghast'a sağ tıklayarak onu yakalayın",

--- a/src/main/resources/assets/create_power_loader/lang/zh_cn.json
+++ b/src/main/resources/assets/create_power_loader/lang/zh_cn.json
@@ -7,9 +7,9 @@
   "block.create_power_loader.empty_brass_chunk_loader": "空的黄铜区块加载器",
   "block.create_power_loader.brass_chunk_loader": "黄铜区块加载器",
   "create_power_loader.brass_chunk_loader.loading_range": "区块加载范围",
-  "create.create_power_loader.brass_chunk_loader.load_1x1": "1x1 矩形",
-  "create.create_power_loader.brass_chunk_loader.load_3x3": "3x3 矩形",
-  "create.create_power_loader.brass_chunk_loader.load_5x5": "5x5 矩形",
+  "create_power_loader.brass_chunk_loader.load_1x1": "1x1 矩形",
+  "create_power_loader.brass_chunk_loader.load_3x3": "3x3 矩形",
+  "create_power_loader.brass_chunk_loader.load_5x5": "5x5 矩形",
 
   "create_power_loader.ponder.empty_chunk_loader_basic.header": "空的区块加载器用法",
   "create_power_loader.ponder.empty_chunk_loader_basic.text_1": "手持空的区块加载器右击恶魂来捕获它",


### PR DESCRIPTION
Before:

![Game shows internal translation key](https://github.com/user-attachments/assets/6bfdafb5-369d-4034-b657-b061ccbc2357)

After:

![Game shows "3×3 Square"](https://github.com/user-attachments/assets/974deedb-7636-4cc4-a92b-5bd15bc4452e)